### PR TITLE
friendly method name

### DIFF
--- a/src/bitcoin_rpc.cr
+++ b/src/bitcoin_rpc.cr
@@ -16,7 +16,7 @@ class BitcoinRpc
   end
 
   macro method_missing(call)
-    command = {{call.name.id.stringify}}
+    command = {{call.name.id.stringify.gsub /_/, "" }}
     {% if call.args.size == 0 %}
       rpc_request(command)
     {% else %}


### PR DESCRIPTION
remove all `_` from method name.
now we can use like this

`client.get_addresses_by_account ""`

it 's more readable. 